### PR TITLE
change ipmitool timeout args format from base 36 to base 10

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -266,7 +266,7 @@ func ipmitoolConfig(config IPMIConfig) []string {
 		args = append(args, "-P", config.Password)
 	}
 	if config.Timeout != 0 {
-		args = append(args, "-N", strconv.FormatInt(config.Timeout, 36))
+		args = append(args, "-N", strconv.FormatInt(config.Timeout, 10))
 	}
 	return args
 }


### PR DESCRIPTION
according to ipmitool man page, Options -N only accepts base 10 numbers as input.